### PR TITLE
Extract body text from alt attribute of img tag

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -52,12 +52,18 @@ task :fetch do
 
   horesasu.each do |meigen|
     yaml_path = DATA_DIR + "#{meigen[:id]}.yml"
+    text_path = BODY_DIR + "#{meigen[:id]}.txt"
+
     break if yaml_path.exist?
+    break if text_path.exist?
 
     puts "[%3s] %s / %s / %s" % [:id, :title, :character, :image].map {|attr| meigen[attr] }
 
+    body = meigen.delete(:body)
+
     yaml = YAML.dump(meigen.stringify_keys)
     File.write(yaml_path, yaml, :encoding => Encoding::UTF_8)
+    File.write(text_path, body, :encoding => Encoding::UTF_8)
 
     sleep 2
   end

--- a/lib/jigokuno.rb
+++ b/lib/jigokuno.rb
@@ -55,6 +55,7 @@ module Jigokuno
         scraped = {
           id:        id_str.tr("０-９", "0-9").to_i,
           title:     title,
+          body:      entry.at(".//img[@class='pict']/@alt").value,
           image:     entry.at(".//img[@class='pict']/@src").value,
           character: category_anchor.text,
           cid:       extract_cid(permalink_of_category),


### PR DESCRIPTION
img タグの alt 属性から本文っぽい文章を取得してとりあえずファイルに吐き出してくれる、という処理を加えてみました。改行の位置を整えたり、足りない文章を補ったり、といった作業は今後も人力になります。

発端: http://kimihito.hatenablog.com/entry/2014/03/18/232944
