### PR TITLE
Accept hankaku numbers

### DIFF
--- a/lib/jigokuno.rb
+++ b/lib/jigokuno.rb
@@ -50,7 +50,7 @@ module Jigokuno
 
         permalink_of_category = category_anchor.attribute("href").value
         permalink_of_article = h1.at("./a/@href").value
-        id_str, title = h1.text.scan(/惚れさせ([０-９]+).*「(.+)」/).first
+        id_str, title = h1.text.scan(/惚れさせ([０-９0-9]+).*「(.+)」/).first
 
         scraped = {
           id:        id_str.tr("０-９", "0-9").to_i,


### PR DESCRIPTION
惚れさせ1926にして初めて、タイトルのID文字列のところが半角数字になるパターンが出現したので、全角と半角のどちらでも解釈できるようにします。

![2016-05-25-09-42-15](https://cloud.githubusercontent.com/assets/3970/15524392/082e7fba-225d-11e6-9aa9-efc1e8f6fe39.png)
